### PR TITLE
Use "available" zones only in subnetDistributor

### DIFF
--- a/dist/subnetDistributor.js
+++ b/dist/subnetDistributor.js
@@ -32,7 +32,7 @@ class SubnetDistributor {
     static perAz(baseCidr) {
         return __awaiter(this, void 0, void 0, function* () {
             const azCount = (yield aws.getAvailabilityZones({
-                state: "available"
+                state: "available",
             })).names.length;
             return new SubnetDistributor(baseCidr, azCount);
         });

--- a/src/subnetDistributor.ts
+++ b/src/subnetDistributor.ts
@@ -26,7 +26,7 @@ export class SubnetDistributor {
      */
     public static async perAz(baseCidr: string): Promise<SubnetDistributor> {
         const azCount = (await aws.getAvailabilityZones({
-            state: "available"
+            state: "available",
         })).names.length;
 
         return new SubnetDistributor(baseCidr, azCount);


### PR DESCRIPTION
This matches the change made earlier to the main Vpc component in a64ec75.