### PR TITLE
Fix installation for Python locally and from Pypi

### DIFF
--- a/python/GNUmakefile
+++ b/python/GNUmakefile
@@ -32,9 +32,9 @@ lint:
 .PHONY: dist
 dist:
 	$(call START_TARGET)
-	$(call START_TASK,Copying and transforming README.md and license...)
+	$(call START_TASK,Copying README.md and license...)
 	cp $(MAKEFILE_ROOT)/../LICENSE $(MAKEFILE_ROOT)
-	pandoc -s -o $(MAKEFILE_ROOT)/README.rst $(MAKEFILE_ROOT)/../README.md
+	cp $(MAKEFILE_ROOT)/../README.md $(MAKEFILE_ROOT)
 	$(call START_TASK,Building source distribution for Python package...)
 	mkdir -p $(ARTIFACT_OUT_DIR)
 	pipenv run python $(MAKEFILE_ROOT)/setup.py sdist \

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,8 +8,12 @@ from setuptools import setup, find_packages
 
 
 def readme():
-    with open('../README.md') as f:
-        return f.read()
+    for filename in ('README.md', '../README.md'):
+        try:
+            with open('README.md') as f:
+                return f.read()
+        except IOError:
+            pass
 
 
 setup(


### PR DESCRIPTION
Two issues existed with the Python package setup:

- Hardcoding the path to `../README.md` fails when installing from a package, but not using `Pipenv` local paths
- We still required Pandoc despite using `text/markdown` as our long description format.

This PR fixes both issues.