### PR TITLE
Update for use with Pulumi v3 & Add VPC Flow Logging to S3

### DIFF
--- a/python/jen20_pulumi_aws_vpc/vpc.py
+++ b/python/jen20_pulumi_aws_vpc/vpc.py
@@ -107,7 +107,7 @@ class Vpc(pulumi.ComponentResource):
                                           cidr_block=cidr,
                                           availability_zone=args.availability_zone_names[i],
                                           map_public_ip_on_launch=True,
-                                          tags={**args.base_tags, "Name": f"${args.description} Public Subnet {i}"},
+                                          tags={**args.base_tags, "Name": f"{args.description} Public Subnet {i}"},
                                           opts=pulumi.ResourceOptions(
                                               parent=self.vpc,
                                           ))
@@ -117,7 +117,7 @@ class Vpc(pulumi.ComponentResource):
                                            vpc_id=self.vpc.id,
                                            cidr_block=cidr,
                                            availability_zone=args.availability_zone_names[i],
-                                           tags={**args.base_tags, "Name": f"${args.description} Private Subnet {i}"},
+                                           tags={**args.base_tags, "Name": f"{args.description} Private Subnet {i}"},
                                            opts=pulumi.ResourceOptions(
                                                parent=self.vpc,
                                            ))
@@ -127,7 +127,7 @@ class Vpc(pulumi.ComponentResource):
         self.public_route_table = ec2.DefaultRouteTable(f"{name}-public-rt",
                                                         default_route_table_id=self.vpc.default_route_table_id,
                                                         tags={**args.base_tags,
-                                                              "Name": f"${args.description} Public Route Table"},
+                                                              "Name": f"{args.description} Public Route Table"},
                                                         opts=pulumi.ResourceOptions(
                                                             parent=self.vpc,
                                                         ))

--- a/python/jen20_pulumi_aws_vpc/vpc.py
+++ b/python/jen20_pulumi_aws_vpc/vpc.py
@@ -217,6 +217,23 @@ class Vpc(pulumi.ComponentResource):
 
         super().register_outputs({})
 
+    def enableFlowLoggingToS3(self, bucketArn: Input[str], trafficType: Input[str]):
+        """
+        Enable VPC flow logging to S3, for the specified traffic type
+        :param self: VPC instance
+        :param bucketArn: The arn of the s3 bucket to send logs to
+        :param trafficType: The traffic type to log: "ALL", "ACCEPT" or "REJECT"
+        :return: None
+        """
+        ec2.FlowLog(f"{self.name}-flow-logs",
+                    log_destination=bucketArn,
+                    log_destination_type="s3",
+                    vpc_id=self.vpc.id,
+                    traffic_type=trafficType,
+                    opts=pulumi.ResourceOptions(
+                       parent=self.vpc,
+                    ))
+
     def enableFlowLoggingToCloudWatchLogs(self, trafficType: Input[str]):
         """
         Enable VPC flow logging to CloudWatch Logs, for the specified traffic type

--- a/python/setup.py
+++ b/python/setup.py
@@ -29,7 +29,7 @@ setup(
     long_description_content_type='text/markdown',
     install_requires=[
         'pulumi>=2.1.0,<4.0.0',
-        'pulumi_aws>=2.2.0,<3.0.0',
+        'pulumi_aws>=2.2.0,<5.0.0',
     ],
     zip_safe=True,
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description=readme(),
     long_description_content_type='text/markdown',
     install_requires=[
-        'pulumi>=2.1.0,<3.0.0',
+        'pulumi>=2.1.0,<4.0.0',
         'pulumi_aws>=2.2.0,<3.0.0',
     ],
     zip_safe=True,


### PR DESCRIPTION
First off, thanks for this pulumi library @jen20!   Very helpful getting a new VPC spun up.

This pull request contributes back a few things I needed:

1. Allows use with Pulumi v3 and the pulumi-aws library v4 by changing the dependency requirements in setup.py
2. Adds the ability to send VPC flow logs to a specified S3 bucket (it assumes the bucket is separately configured).
3. Removes the extra dollar signs in the route table and subnet table Name tags

Thoughts?